### PR TITLE
regression-analysis: remove In_scope from badfixstats.py output

### DIFF
--- a/development-process/stable-maintenance/regression-analysis/badfixfilter.py
+++ b/development-process/stable-maintenance/regression-analysis/badfixfilter.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2019 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+import argparse
+import csv
+import os
+import sys
+
+import pandas as pd
+
+################################################################################
+
+
+def df_from_csv_file(name):
+    df = pd.read_csv(name, na_values=[''], keep_default_na=False)
+    df.reset_index(drop=True, inplace=True)
+    return df
+
+
+def df_to_csv_file(df, name):
+    df.to_csv(
+        path_or_buf=name,
+        quoting=csv.QUOTE_ALL,
+        sep=",", index=False, encoding='utf-8')
+    print("[+] Wrote: %s" % name)
+
+
+def filter_csv(db, column, filter, out):
+    # Dataframe from db-file
+    df_db = df_from_csv_file(db)
+
+    # Dataframe from filter
+    df_filter = pd.read_csv(filter, header=None, names=['filter'])
+    df_filter.reset_index(drop=True, inplace=True)
+    df_filter.drop_duplicates(inplace=True)
+
+    # Merge to filter df_db
+    df = df_db.merge(
+        df_filter,
+        how='left',
+        left_on=[column],
+        right_on=['filter'],
+        indicator=True,
+    )
+
+    # Only keep the rows that are in both
+    df = df[df['_merge'] == 'both']
+
+    # Drop the intermediate columns 'filter' and 'merge'
+    df.drop(['filter', '_merge'], axis=1, inplace=True)
+    df_to_csv_file(df, out)
+
+
+def exit_unless_accessible(filename):
+    if not os.path.isfile(filename):
+        sys.stderr.write(
+            "Error: file not found or no permissions: %s\n" % filename)
+        sys.exit(1)
+
+
+def getargs():
+    desc = \
+        "Filter data generated with badfixstats.py. "\
+        "Given badfix database (--db), "\
+        "filter the database by only outputting "\
+        "the rows where specified column (--col) values match "\
+        "any of the lines in the text file (--filter). "\
+
+    epil = "Example: ./%s --db badfixdb.csv --col Commit_hexsha "\
+        "--filter patchlist.txt" % \
+        os.path.basename(__file__)
+    parser = argparse.ArgumentParser(description=desc, epilog=epil)
+
+    required_named = parser.add_argument_group('required named arguments')
+    help = "CSV database to be filtered (output from badfixstats.py)"
+    required_named.add_argument('--db', help=help, required=True)
+
+    help = "CSV database column name"
+    required_named.add_argument('--col', help=help, required=True)
+
+    help = "Text file specifying the accepted values, one value per line"
+    required_named.add_argument('--filter', help=help, required=True)
+
+    help = \
+        "set the output file name, default is the db-name, prefixed with "\
+        " __filtered.csv"
+    parser.add_argument('--out', nargs='?', help=help, default='')
+
+    return parser.parse_args()
+
+################################################################################
+
+
+if __name__ == "__main__":
+    args = getargs()
+
+    exit_unless_accessible(args.db)
+    exit_unless_accessible(args.filter)
+
+    out = args.out
+    if not out:
+        out = "%s__filtered.csv" % args.db
+
+    filter_csv(args.db, args.col, args.filter, out)
+
+################################################################################

--- a/development-process/stable-maintenance/regression-analysis/patchfilter-tool.py
+++ b/development-process/stable-maintenance/regression-analysis/patchfilter-tool.py
@@ -88,6 +88,8 @@ def getargs():
         "The script can be used to reduce the patches in the range REV to "\
         "those that are relevant for the kernel configuration that was used "\
         "in building the vmlinux and the modules. "\
+        "The script expects DWARF debug sections (CONFIG_DEBUG_INFO=y) "\
+        "in the object files. "\
         "Note: the script produces a list of files that were used to "\
         "compile the _current_ version of vmlinux and modules found under "\
         "the LINUX_DIR. "\
@@ -158,11 +160,9 @@ if __name__ == '__main__':
     with open(objdumpfile, 'a') as outfile:
         cmd = 'objdump -Wl %s' % vmlinux
         exec_cmd(cmd, stdout=outfile)
-    print("[+] Wrote: %s" % objdumpfile)
 
     # Parse objdump
     with open(objdumpfile, 'r') as infile, open(filelistfile, 'w') as outfile:
-        print("[+] Wrote: %s" % filelistfile)
         if not parse_objdump(infile, outfile, linux_dir):
             sys.stderr.write(
                 "Error: parsing objdump failed\n"
@@ -175,9 +175,16 @@ if __name__ == '__main__':
     # Generate patchlist
     with open(filelistfile, 'r') as infile, open(patchlistfile, 'w') as outfile:
         cmd = \
-            'git --git-dir=%s log --oneline '\
+            'git --git-dir=%s log --format=format:%%H '\
             '--no-merges %s -- `cat %s`' % (repo, rev, filelistfile)
         exec_cmd(cmd, stdout=outfile)
+
+    print("[+] Wrote: %s" % filelistfile)
+    # os.remove(filelistfile)
+
+    # Remove the intermediate files
+    os.remove(objdumpfile)
+
     print("[+] Wrote: %s" % patchlistfile)
 
 ###############################################################################


### PR DESCRIPTION
- Get rid of In_scope-column from the badfixstats.py output, and
the '--inscope' command line argument. Instead, provide an additional
tool that allows filtering the given badfixstats.py output to produce
the same result, but without having to re-run the badfixstats.py.

- Add badfixfilter.py that allows post-processing badfixstats.py output
to e.g. filter by a patchlist.txt

- Change patchfilter-tool.py to remove the intermediate objectdump file