### PR TITLE
callgraph-tool: update README.md for an environment where python defaults as python2

### DIFF
--- a/safety-architecture/tools/callgraph-tool/README.md
+++ b/safety-architecture/tools/callgraph-tool/README.md
@@ -13,7 +13,7 @@ Call Graph is tool for studying call graphs between different function calling p
 
 ## Prerequisites
 ```
-pip install -r requirements.txt
+pip3 install -r requirements.txt
 ```
 In order to be able to generate the call graph database, it is required to install llvm tools
 ```


### PR DESCRIPTION
callgraph-tool.py implicitly implicitly python3.
On the other hand, python package install description is using default python version pip.
When user environment default is python2, pip is used by python2 version.
In this case, python3 package will not be installed.

This patch modify to python package install description.