### PR TITLE
Force pytest upgrade

### DIFF
--- a/development-process/stable-maintenance/regression-analysis/Makefile
+++ b/development-process/stable-maintenance/regression-analysis/Makefile
@@ -17,6 +17,7 @@ help: ## Show this help message
 install-requirements:  ## Install all requirements
 	pip3 install -r requirements.txt --no-cache-dir
 	pip3 install -r requirements-dev.txt --no-cache-dir
+	pip3 install --upgrade pytest
 	$(call target_success,$@)
 
 pre-push: test style clean ## Run tests, pycodestyle, and reuse-lint


### PR DESCRIPTION
Force pytest upgrade in order to avoid failing tests caused by pkg_resources.VersionConflict
error.

Signed-off-by: Marijo Simunovic <simunovic.marijo@gmail.com>