### PR TITLE
callgraph-tool: remove test timeout

### DIFF
--- a/safety-architecture/tools/callgraph-tool/requirements.txt
+++ b/safety-architecture/tools/callgraph-tool/requirements.txt
@@ -17,3 +17,4 @@ pytest
 pytest-cov
 reuse
 IPython
+graphviz

--- a/safety-architecture/tools/callgraph-tool/tests/test_callgraph_tool.py
+++ b/safety-architecture/tools/callgraph-tool/tests/test_callgraph_tool.py
@@ -373,7 +373,7 @@ def test_callgraph_view_graph(set_up_test_data):
                                      "--view", "--view_type", "dot",
                                     "--coverage_file", "coverage_file.txt"],
                                     cwd=ROOT_FOLDER + "/callgraph_tool_test_data",
-                                    stdout=subprocess.PIPE, timeout=1)
+                                    stdout=subprocess.PIPE)
     assert process_result.returncode == 0
     dotfile = ROOT_FOLDER + "/callgraph_tool_test_data/callgraph.dot"
     assert os.path.isfile(dotfile)


### PR DESCRIPTION
Remove timeout-parameter from the testcase: test_callgraph_view_graph.
The timeout-parameter was relic from an earlier test implementation,
which is no longer needed.

Add graphviz to requirement.txt due to requirement introduced in
clang_graph_calls.py.