### PR TITLE
callgraph-tool: graph view: remove node with three dots

### DIFF
--- a/safety-architecture/tools/callgraph-tool/service.py
+++ b/safety-architecture/tools/callgraph-tool/service.py
@@ -306,7 +306,6 @@ class Service:
                                                                view_base_dir=view_base_dir)
 
             if lvl >= max_depth:
-                self._dot_source += '"%s" -> "..."\n' % (function.name)
                 return
         else:
             pad = ''
@@ -321,7 +320,6 @@ class Service:
                 self.functionality_writer(callees_str)
 
             if lvl >= max_depth:
-                self.functionality_writer('%s  ...' % (pad))
                 return
 
         for callee in callees:
@@ -372,8 +370,6 @@ class Service:
                                                                view_base_dir=view_base_dir)
 
             if lvl >= max_depth:
-                self._dot_source += '"%s" -> "..." [dir=back]\n' % (
-                    function.name)
                 return
         else:
             callers_str = '%s%s <- %s' % (pad, function,
@@ -384,7 +380,6 @@ class Service:
                 self.functionality_writer(callers_str)
 
             if lvl >= max_depth:
-                self.functionality_writer('%s  ...' % (pad))
                 return
 
         for caller in callers:


### PR DESCRIPTION
It is misleading to draw an edge from a function to node with three dots
(...), since the graph output already includes all the known connected
nodes (for the specified depth-level). Most users would likely interpret the
meaning of three dots as the graph being incomplete for the given depth,
which was clearly not indented.
