### PR TITLE
Fix problems with exclude argument for LL_CLANG builds

### DIFF
--- a/safety-architecture/tools/callgraph-tool/build.py
+++ b/safety-architecture/tools/callgraph-tool/build.py
@@ -22,6 +22,13 @@ def valid_llvm_extensions():
     return LLVM_EXT
 
 
+def get_build_root(buildpath):
+    path = os.path.expanduser(buildpath)
+    if not os.path.isdir(path):
+        path = os.path.dirname(path)
+    return os.path.abspath(os.path.normpath(path))
+
+
 class BuildLogFormat(Enum):
     KERNEL_C = 'kernel_c'
     KERNEL_CLANG = 'kernel_clang'
@@ -83,6 +90,7 @@ def clang_indexer_build(args, call_graph):
 
 
 def build_call_graph(args, call_graph):
+    args.projroot = args.projroot if args.projroot else get_build_root(args.build[0])
     args.build[0] = convert_build_file(args.build[0], args.build_log_format)
 
     if args.build_log_format == BuildLogFormat.AST_CLANG:
@@ -328,6 +336,8 @@ class Engine(object):
             self.Command = ClangKernel
         elif args.build_log_format == BuildLogFormat.LL_CLANG:
             self.Command = ClangLL
+            self.build_exclude = [args.projroot + '/' +
+                                  exclude for exclude in self.build_exclude]
         elif args.build_log_format == BuildLogFormat.CPLUSPLUS:
             self.Command = ClangCpp
         else:

--- a/safety-architecture/tools/callgraph-tool/callgraph-tool.py
+++ b/safety-architecture/tools/callgraph-tool/callgraph-tool.py
@@ -73,6 +73,8 @@ def get_args():
                             '  ' + BuildLogFormat.AST_CLANG.value + ' = reads compile_commands.json database\n'
                             '  ' + BuildLogFormat.CPLUSPLUS.value + ' = plain build log from c++ builds')
     build_args.add_argument('--build_exclude', '-be', default='tools,scripts', help='Exclude files/directories')
+    build_args.add_argument('--projroot', default='', help='Path to the source code for which we build call graph.\n'
+                            'If not specified, path is deduced from build argument.')
     build_args.add_argument('--build_trigger_map', action='store_true', help='Build flat trigger map only')
     build_args.add_argument('--arch', default='x86', help='Target architecture')
     build_args.add_argument('--clang', default='clang', help='Path to clang executable')

--- a/safety-architecture/tools/callgraph-tool/tests/unittests/test_build.py
+++ b/safety-architecture/tools/callgraph-tool/tests/unittests/test_build.py
@@ -9,9 +9,29 @@ import unittest
 callgraphtool_path = os.path.dirname(os.path.abspath(__file__)) + '/../..'
 sys.path.append(callgraphtool_path)
 
-from build import valid_llvm_extensions  # noqa E402
+from build import valid_llvm_extensions, get_build_root  # noqa E402
 
 
 def test_valid_llvm_extensions():
     assert '.ll' in valid_llvm_extensions()
     assert '.llvm' in valid_llvm_extensions()
+
+
+def test_get_build_root():
+    p1 = '~/work/project/buildlog1.txt'
+    p2 = '/home/user/project/buildlog.txt'
+    p3 = '~/buildlog.txt'
+    p4 = '/buildlog.txt'
+    p5 = '/'
+    p6 = '~/'
+    p7 = '/tmp'
+    p8 = '/tmp/../'
+    home = os.path.expanduser("~")
+    assert home + '/work/project' == get_build_root(p1)
+    assert '/home/user/project' == get_build_root(p2)
+    assert home == get_build_root(p3)
+    assert '/' == get_build_root(p4)
+    assert '/' == get_build_root(p5)
+    assert home == get_build_root(p6)
+    assert '/tmp' == get_build_root(p7)
+    assert '/' == get_build_root(p8)


### PR DESCRIPTION
Bugfix: Default build_exclude argument (tool) cause omitting the files inside of the callgraph tool due to new
project hierarchy.

Signed-off-by: Marijo Simunovic <simunovic.marijo@gmail.com>