### PR TITLE
Fix: make system include usage configurable

### DIFF
--- a/safety-architecture/tools/callgraph-tool/callgraph-tool.py
+++ b/safety-architecture/tools/callgraph-tool/callgraph-tool.py
@@ -85,6 +85,8 @@ def get_args():
                             'write enriched call_graph as <original pickle file>.ftrace')
     build_args.add_argument('--fast_build', '-fb', action='store_true',
                             help='Enable to quick build without recompiling sources (reuse existing llvm files)')
+    build_args.add_argument('--isystem', choices=['auto', 'none'], default='none',
+                            help='Detect system include path (defaults to "none")')
 
     # Search arguments
     search_args = parser.add_argument_group('Search arguments')


### PR DESCRIPTION
Native projects would failed building due to hard-coded exclusion of builtin includes. Make this behavior
configurable through command line options

Signed-off-by: Marijo Simunovic <simunovic.marijo@gmail.com>