### PR TITLE
Clean up crix includes

### DIFF
--- a/safety-architecture/tools/callgraph-tool/src/lib/Analyzer.cc
+++ b/safety-architecture/tools/callgraph-tool/src/lib/Analyzer.cc
@@ -6,31 +6,15 @@
 // ===-----------------------------------------------------------===//
 
 #include "llvm/Bitcode/BitcodeReader.h"
-#include "llvm/Bitcode/BitcodeWriter.h"
-#include "llvm/IR/LLVMContext.h"
-#include "llvm/IR/Module.h"
-#include "llvm/IR/PassManager.h"
-#include "llvm/IR/Verifier.h"
 #include "llvm/IRReader/IRReader.h"
-#include "llvm/Support/FileSystem.h"
-#include "llvm/Support/ManagedStatic.h"
-#include "llvm/Support/Path.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/PrettyStackTrace.h"
 #include "llvm/Support/Signals.h"
-#include "llvm/Support/SourceMgr.h"
-#include "llvm/Support/SystemUtils.h"
-#include "llvm/Support/ToolOutputFile.h"
 
-#include <memory>
-#include <sstream>
-#include <sys/resource.h>
-#include <vector>
-
-#include "Analyzer.h"
 #include "CallGraph.h"
-#include "Common.h"
 
 using namespace llvm;
+using namespace std;
 
 // Command line parameters.
 cl::list<string> InputFilenames(cl::Positional, cl::OneOrMore,

--- a/safety-architecture/tools/callgraph-tool/src/lib/Analyzer.h
+++ b/safety-architecture/tools/callgraph-tool/src/lib/Analyzer.h
@@ -1,23 +1,9 @@
 #ifndef ANALYZER_GLOBAL_H
 #define ANALYZER_GLOBAL_H
 
-#include "llvm/Support/CommandLine.h"
 #include <fstream>
-#include <iostream>
-#include <llvm/ADT/DenseMap.h>
-#include <llvm/ADT/SmallPtrSet.h>
-#include <llvm/ADT/StringExtras.h>
-#include <llvm/IR/DebugInfo.h>
-#include <llvm/IR/Instructions.h>
-#include <llvm/IR/Module.h>
-#include <llvm/Support/Path.h>
-#include <llvm/Support/raw_ostream.h>
-#include <map>
-#include <set>
 #include <sstream>
-#include <string>
 #include <unordered_map>
-#include <unordered_set>
 
 #include "Common.h"
 

--- a/safety-architecture/tools/callgraph-tool/src/lib/CallGraph.cc
+++ b/safety-architecture/tools/callgraph-tool/src/lib/CallGraph.cc
@@ -10,33 +10,14 @@
 //
 //===-----------------------------------------------------------===//
 
-#include "llvm/Analysis/LoopInfo.h"
-#include "llvm/Analysis/LoopPass.h"
-#include "llvm/IR/BasicBlock.h"
-#include "llvm/IR/CFG.h"
-#include "llvm/IR/Function.h"
 #include "llvm/IR/IRBuilder.h"
-#include "llvm/IR/InstrTypes.h"
-#include "llvm/IR/Instruction.h"
-#include "llvm/Support/raw_ostream.h"
+#include "llvm/IR/InstIterator.h"
 #include "llvm/Transforms/Utils/BasicBlockUtils.h"
-#include <llvm/ADT/StringExtras.h>
-#include <llvm/Analysis/CallGraph.h>
-#include <llvm/IR/Constants.h>
-#include <llvm/IR/DebugInfo.h>
-#include <llvm/IR/InstIterator.h>
-#include <llvm/IR/Instructions.h>
-#include <llvm/IR/LegacyPassManager.h>
-#include <llvm/IR/Module.h>
-#include <llvm/Pass.h>
-#include <llvm/Support/Debug.h>
-#include <map>
-#include <vector>
 
 #include "CallGraph.h"
-#include "Common.h"
 
 using namespace llvm;
+using namespace std;
 
 DenseMap<size_t, FuncSet> CallGraphPass::typeFuncsMap;
 unordered_map<size_t, set<size_t>> CallGraphPass::typeTransitMap;

--- a/safety-architecture/tools/callgraph-tool/src/lib/Common.cc
+++ b/safety-architecture/tools/callgraph-tool/src/lib/Common.cc
@@ -1,8 +1,6 @@
+#include "llvm/IR/DebugInfoMetadata.h"
+
 #include "Common.h"
-#include <fstream>
-#include <llvm/IR/InlineAsm.h>
-#include <llvm/IR/InstIterator.h>
-#include <regex>
 
 size_t funcHash(Function *F, bool withName) {
 

--- a/safety-architecture/tools/callgraph-tool/src/lib/Common.h
+++ b/safety-architecture/tools/callgraph-tool/src/lib/Common.h
@@ -2,15 +2,6 @@
 #define COMMON_H
 
 #include <llvm/Analysis/TargetLibraryInfo.h>
-#include <llvm/IR/DebugInfo.h>
-#include <llvm/IR/Module.h>
-#include <llvm/Support/CommandLine.h>
-#include <llvm/Support/raw_ostream.h>
-
-#include <bitset>
-#include <chrono>
-#include <stdio.h>
-#include <unistd.h>
 
 using namespace llvm;
 using namespace std;


### PR DESCRIPTION
Cleaning up stale LLVM includes to improve readability

Signed-off-by: Marijo Simunovic <simunovic.marijo@gmail.com>