### PR TITLE
crix-callgraph: use arguments with env.sh

### DIFF
--- a/safety-architecture/tools/callgraph-tool/doc/using_custom_llvm.md
+++ b/safety-architecture/tools/callgraph-tool/doc/using_custom_llvm.md
@@ -29,9 +29,9 @@ To compile crix-callgraph using the custom version of LLVM, run:
 cd $CG_DIR
 
 # Make sure correct version of clang is in $PATH. 
-# Notice the argument './clang' which indicates the directory that
+# Notice the argument '--clangdir ./clang' which indicates the directory that
 # contains the clang binaries somewhere in the directory hierarchy
-source env.sh ./clang
+source env.sh --clangdir ./clang
 
 # Clean
 make clean
@@ -44,4 +44,4 @@ make LLVM_DIR=./clang/bin/ LLVM_VERSION=11.0.0
 # Now, you can find the executable in `build/lib/crix-callgraph`
 ```
 ## Building kernel with custom LLVM
-Make sure the correct version of clang is in the PATH before any other version of clang by setting the environment with `cd $CG_DIR && source env.sh ./clang` before building the kernel. Then, follow the instructions e.g. from the main [README](../README.md#generate-bitcode-files-from-the-target-program) to build the kernel and generate bitcode files.
+Make sure the correct version of clang is in the PATH before any other version of clang by setting the environment with `cd $CG_DIR && source env.sh -c ./clang` before building the kernel. Then, follow the instructions e.g. from the main [README](../README.md#generate-bitcode-files-from-the-target-program) to build the kernel and generate bitcode files.

--- a/safety-architecture/tools/callgraph-tool/env.sh
+++ b/safety-architecture/tools/callgraph-tool/env.sh
@@ -4,29 +4,77 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-if [ ! -z "$1" ]; then
-    # If an argument is given, assume it's either relative or absolute
-    # path to directory that contains clang binaries somewhere in the
-    # directory hierarchy
-    absdir=$(cd $1 2>/dev/null && pwd)
-    if [ -z $absdir ] || [ ! -d $absdir ]; then
-        echo "Error: '$1' does not exist."
-        return
-    fi
-    # Find the path to an executable we know should exist in the clang bin 
-    # directory. From the path to executable, find the path to bin/ directory.
-    CLANG_BIN_DIR=$(find $absdir -name 'clang++' -executable -print -quit 2>/dev/null | grep -oE ".*bin")
-    if [ -z $CLANG_BIN_DIR ]; then
-        echo "Error: could not find clang binary directory from '$absdir'"
-        return
-    fi
-else
-    CLANG_BIN_DIR=/usr/lib/llvm-10/bin
+################################################################################
+
+MYNAME=$0
+
+usage () {
+    echo "Usage: $MYNAME [--clangdir DIR]"
+    echo ""
+    echo "Set environment variables for crix-callgraph"
+    echo ""
+}
+
+################################################################################
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    echo "Error: this script needs to be sourced, not executed."
+    echo "Re-run with: 'source $MYNAME $@'"
+    exit 1
 fi
+
+################################################################################
+
+# Transform long options to short ones
+for arg in "$@"; do
+  shift
+  case "$arg" in
+    "--help")     set -- "$@" "-h" ;;
+    "--clangdir") set -- "$@" "-c" ;;
+    *)            set -- "$@" "$arg"
+  esac
+done
+
+# Default
+clangdir='/usr/lib/llvm-10/bin'
+
+# Parse short options
+OPTIND=1
+while getopts "hc:" opt
+do
+  case "$opt" in
+    "h") usage; return ;;
+    "c") clangdir=$OPTARG ;;
+    "?") usage; return ;;
+    "--"*) usage; return ;;
+  esac
+done
+# remove options from positional parameters
+shift $(expr $OPTIND - 1)
+
+################################################################################
+
+# $clangdir now contains either relative or absolute
+# path to directory that contains clang binaries somewhere in the
+# directory hierarchy
+absdir=$(cd $clangdir 2>/dev/null && pwd)
+if [ -z $absdir ] || [ ! -d $absdir ]; then
+    echo "Error: '$clangdir' does not exist."
+    return 
+fi
+# Find the path to an executable we know should exist in the clang bin 
+# directory. From the path to executable, find the path to bin/ directory.
+CLANG_BIN_DIR=$(find $absdir -name 'clang++' -executable -print -quit 2>/dev/null | grep -oE ".*bin")
+if [ -z $CLANG_BIN_DIR ]; then
+    echo "Error: could not find clang binary directory from '$absdir'"
+    return
+fi
+
 echo "Using CLANG_BIN_DIR=${CLANG_BIN_DIR}"
+
 if [ ! -d $CLANG_BIN_DIR ]; then
     echo "Error: '$CLANG_BIN_DIR' does not exist."
-    return 
+    return
 fi
 
 export LLVM_COMPILER=clang
@@ -36,3 +84,5 @@ PATH=${CLANG_BIN_DIR}:${PATH}:${HOME}/.local/bin/
 # Remove duplicates from the PATH, preserving order
 PATH=$(n= IFS=':'; for e in $PATH; do [[ :$n == *:$e:* ]] || n+=$e:; done; echo "${n:0: -1}")
 export PATH=${PATH}
+
+################################################################################


### PR DESCRIPTION
Modify env.sh to require possible command line arguments with options
specifier, instead of positional parameters.