### PR TITLE
crix-callgraph: fix a use-after-scope memory error in VirtualCallTargets.cpp

### DIFF
--- a/safety-architecture/tools/callgraph-tool/src/lib/VirtualCallTargets.cc
+++ b/safety-architecture/tools/callgraph-tool/src/lib/VirtualCallTargets.cc
@@ -145,7 +145,7 @@ private:
                 const std::vector<llvm::wholeprogramdevirt::VirtualCallTarget>
                     TargetsForSlot);
 
-  llvm::function_ref<llvm::DominatorTree &(llvm::Function &)> LookupDomTree;
+  std::function<llvm::DominatorTree &(llvm::Function &)> LookupDomTree;
   VTableSlotCallSitesMap CallSlots;
   VirtualCallTargetsResult m_results;
 };


### PR DESCRIPTION
`llvm::function_ref` stores a reference but does not own a callable object [1]. `LookupDomTree` of that type is assigned to a local lambda object in `VirtualCallTargets::run()` and is used later in `VirtualCallTargets::scanTypeTestUsers()`, but the local lambda object is already out of scope at that time, and crashes the program on my computer. This pull request changes the type of `LookupDomTree` to `std::function`, which owns a callable object.

[[1] LLVM reference](https://llvm.org/doxygen/classllvm_1_1function__ref.html)

---

Signed-off-by: Binrui Dong <brett.browning.dong@gmail.com>