### PR TITLE
Add meeting guidelines including recording

### DIFF
--- a/meeting-rules.md
+++ b/meeting-rules.md
@@ -27,10 +27,16 @@ transcription features (e.g., Zoom transcripts):
 - **Agreement Before Enabling**  
   - All participants must **explicitly agree** before enabling recording or transcription.
   - The agreement must be documented in the **meeting minutes**.
+  - Participants joining after recording has started are notified by the meeting tool (Zoom)
+    that a recording is in progress and have the freedom of choice to speak, or not, and 
+    notify whether they agree, or disagree to be recorded.
 
 - **Usage and Sharing**  
   - Any recordings or transcripts are for **personal use only** by participants.
   - They **must not be shared publicly** or distributed beyond the agreed scope.
+  - WARNING: Transcripts are still known to be NOT reliable in the identification of the exact words used, 
+    in particular within specific domains like Functional Safety. So, they shall NOT and cannot NOT be trusted 
+    without confirmation of the speaker, to confirm understanding.
 
 - **Documentation**  
   - Meeting minutes should clearly state:
@@ -49,3 +55,36 @@ Purpose: Personal reference only, no sharing
 **Note:** *Any meeting before September 2025 misses information about recording or
 transcript, as the rule was not in place. The rules were jointly discussed and agreed
 in the [TSC meeting August 20th 2025](https://github.com/elisa-tech/tsc/wiki/20-Aug-2025#meeting-recordings-and-transcriptions).*
+
+## Antitrust policy
+
+All ELISA meetings follow valid antitrust policies as stated by the Linux Foundation. 
+[LF Antitrust Policy](https://www.linuxfoundation.org/legal/antitrust-policy)
+
+
+## Code of Conduct
+
+The kernel and LF Code of Conduct applies to all communication with this project:
+
+* https://www.linuxfoundation.org/code-of-conduct/
+* https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/process/code-of-conduct.rst
+* https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/process/code-of-conduct-interpretation.rst
+
+## Copyright and Licensing
+
+Email communication will be treated as documentation and be received and made available by the Project under the 
+Creative Commons Attribution 4.0 International License (available at http://creativecommons.org/licenses/by/4.0/). 
+Please refer to the ELISA Technical Charter section 7 subsection iv. for details.
+
+This also holds for any content presented in meetings and placed in the Google Drive directories.
+
+Note: If you disagree with those terms, you need to point out that the provided content is not under those terms, 
+please let us know beforehand and we will ensure to have clear licensing conditions for all content in this collaboration.
+
+## Clarification on Relationship to Employing Companies
+The discussions in these meetings are exploratory. The opinions expressed by participants are not necessarily the policy of the companies.
+
+## Technical Charter
+
+ELISA Project contributions and WG discussions are subject to and governed by the 
+[Technical Charter](https://elisa.tech/wp-content/uploads/sites/75/2020/08/elisa_technical_charter_082620.pdf)

--- a/meeting-rules.md
+++ b/meeting-rules.md
@@ -1,0 +1,51 @@
+# ELISA Meeting Guidelines
+
+These guidelines apply to all working group meetings within the ELISA project to ensure
+effective collaboration, transparency, and respect for participants.
+
+
+## General Meeting Rules
+- **Send invitations upfront**  
+  Ensure all participants receive a calendar invitation well in advance of the meeting.
+  This is guaranteed by the lfx Zoom account for scheduled meetings.
+
+- **Prepare and share an agenda**  
+  An agenda should be distributed before the meeting and followed during the session.
+
+- **Create and share meeting minutes**  
+  Document key decisions, action items, and agreements in the meeting minutes and share
+  them with participants.
+
+
+## Recording and Transcription Rules
+To protect privacy and maintain trust, the following rules apply to recording and
+transcription features (e.g., Zoom transcripts):
+
+- **Default Setting**  
+  - Recording and transcription are **disabled by default**.
+
+- **Agreement Before Enabling**  
+  - All participants must **explicitly agree** before enabling recording or transcription.
+  - The agreement must be documented in the **meeting minutes**.
+
+- **Usage and Sharing**  
+  - Any recordings or transcripts are for **personal use only** by participants.
+  - They **must not be shared publicly** or distributed beyond the agreed scope.
+
+- **Documentation**  
+  - Meeting minutes should clearly state:
+    - Whether recording or transcription was enabled.
+    - That all participants agreed to it.
+
+### Example for documentation in meeting minutes
+
+This is just an example and can be adjusted. It is mainly important to document this.
+```
+Recording/Transcription: Enabled
+Agreement: All participants agreed before enabling
+Purpose: Personal reference only, no sharing
+```
+
+**Note:** *Any meeting before September 2025 misses information about recording or
+transcript, as the rule was not in place. The rules were jointly discussed and agreed
+in the [TSC meeting August 20th 2025](https://github.com/elisa-tech/tsc/wiki/20-Aug-2025#meeting-recordings-and-transcriptions).*


### PR DESCRIPTION
As a result from TSC discussions, we would like to have general rules on how recordings or transcripts of meetings are handled.
This PR proposes these changes.